### PR TITLE
Feature / Issue #10: ADS 2.0 import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "2.7"
 install:
   - pip install -r requirements.txt
+  - pip install -r dev-requirements.txt
 addons:
   postgresql: "9.3"
 script: nosetests --with-coverage harbour/tests/unit_tests

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,7 @@
+moto
+mock
+nose
+coveralls
+requests==2.7.0
+httmock==1.2.3
+testing.postgresql==1.2.1

--- a/harbour/config.py
+++ b/harbour/config.py
@@ -5,6 +5,10 @@ ADS_CLASSIC_MIRROR_LIST = ['adstrio.cfa.harvard.edu', 'adsnun.cfa.harvard.edu', 
                            'ukads.nottingham.ac.uk', 'ads.iucaa.ernet.in', 'ads.inasan.ru', 'ads.bao.ac.cn',
                            'ads.mao.kiev.ua', 'ads.ari.uni-heidelberg.de', 'ads.arsip.lipi.go.id', 'ads.on.br',
                            'saaoads.chpc.ac.za', 'adsabs.harvard.edu']
+ADS_TWO_POINT_OH_S3_MONGO_BUCKET = 'adsabs-mongogut'
+ADS_TWO_POINT_OH_LOADED_USERS = False
+ADS_TWO_POINT_OH_USERS = {}
+
 SQLALCHEMY_BINDS = {'harbour': ''}
 
 HARBOUR_LOGGING = {

--- a/harbour/http_errors.py
+++ b/harbour/http_errors.py
@@ -38,3 +38,18 @@ NO_CLASSIC_ACCOUNT = dict(
     message='This user has not setup an ADS Classic account',
     code=400
 )
+
+NO_TWOPOINTOH_ACCOUNT = dict(
+    message='This user has not setup an ADS 2.0 account',
+    code=400
+)
+
+NO_TWOPOINTOH_LIBRARIES = dict(
+    message='This user has no ADS 2.0 libraries',
+    code=400
+)
+
+TWOPOINTOH_AWS_PROBLEM = dict(
+    message='Unknown AWS problems',
+    code=500
+)

--- a/harbour/tests/unit_tests/base.py
+++ b/harbour/tests/unit_tests/base.py
@@ -9,7 +9,27 @@ from harbour import app
 from harbour.models import db
 
 
-class TestBaseDatabase(TestCase):
+class TestBase(TestCase):
+    """
+    Base class, bear minimal
+    """
+    def create_app(self):
+        """
+        Create the wsgi application
+        """
+        app_ = app.create_app()
+        app_.config['CLASSIC_LOGGING'] = {}
+        app_.config['SQLALCHEMY_BINDS'] = {}
+        app_.config['ADS_CLASSIC_MIRROR_LIST'] = [
+            'mirror.com', 'other.mirror.com'
+        ]
+        app_.config['SQLALCHEMY_BINDS']['harbour'] = \
+            TestBaseDatabase.postgresql_url
+
+        return app_
+
+
+class TestBaseDatabase(TestBase):
     """
     Base test class for when databases are being used.
     """
@@ -26,21 +46,6 @@ class TestBaseDatabase(TestCase):
             port=postgresql_url_dict['port'],
             database=postgresql_url_dict['database']
         )
-
-    def create_app(self):
-        """
-        Create the wsgi application
-        """
-        app_ = app.create_app()
-        app_.config['CLASSIC_LOGGING'] = {}
-        app_.config['SQLALCHEMY_BINDS'] = {}
-        app_.config['ADS_CLASSIC_MIRROR_LIST'] = [
-            'mirror.com', 'other.mirror.com'
-        ]
-        app_.config['SQLALCHEMY_BINDS']['harbour'] = \
-            TestBaseDatabase.postgresql_url
-
-        return app_
 
     @classmethod
     def setUpClass(cls):

--- a/harbour/tests/unit_tests/test_app.py
+++ b/harbour/tests/unit_tests/test_app.py
@@ -1,0 +1,58 @@
+"""
+Test webservices
+"""
+
+import mock
+import json
+import boto3
+
+from unittest import TestCase
+from moto import mock_s3
+from harbour.app import create_app
+
+
+class TestApp(TestCase):
+    """
+    Test the application, such things as create_app
+    """
+
+    @mock_s3
+    def test_load_s3_create_app_mongo_load_success(self):
+        """
+        Test that when the application is created, that the mongo user data
+        is loaded from s3, if available.
+        """
+        stub_mongogut_users = {
+            'user@ads.com': 'cb16a523-cdba-406b-bfff-edfd428248be.json'
+        }
+
+        s3_resource = boto3.resource('s3')
+        s3_resource.create_bucket(Bucket='adsabs-mongogut')
+        bucket = s3_resource.Bucket('adsabs-mongogut')
+
+        # First is libraries
+        bucket.put_object(
+            Key='users.json',
+            Body=json.dumps(stub_mongogut_users)
+        )
+
+        app = create_app()
+
+        self.assertTrue(app.config['ADS_TWO_POINT_OH_LOADED_USERS'])
+        self.assertEqual(
+            app.config['ADS_TWO_POINT_OH_USERS'],
+            stub_mongogut_users
+        )
+
+    @mock.patch('harbour.app.boto3.resource')
+    def test_load_s3_create_app_mongo_load_success(self, mock_resource):
+        """
+        Test that when the application is created, that the mongo user data
+        is loaded from s3, if available.
+        """
+        mock_resource.side_effect = Exception
+
+        app = create_app()
+
+        self.assertFalse(app.config['ADS_TWO_POINT_OH_LOADED_USERS'])
+        self.assertEqual(app.config['ADS_TWO_POINT_OH_USERS'], {})

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -1,6 +1,6 @@
 # Some const. variables
 $path_var = '/usr/bin:/usr/sbin:/bin:/usr/local/sbin:/usr/sbin:/sbin'
-$build_packages = ['python', 'python-dev', 'python-pip', 'git', 'libpq-dev', 'ipython', 'postgresql-client-9.3']
+$build_packages = ['python', 'python-dev', 'python-pip', 'git', 'libpq-dev', 'ipython', 'postgresql-client-9.3', 'postgresql-9.3']
 $pip_requirements = '/vagrant/requirements.txt'
 
 # Update package list

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,6 @@ flask-consulate==0.1.2
 Flask-SQLAlchemy==2.1
 Flask-Script==2.0.5
 Flask-Migrate==1.6.0
-nose
-coveralls
-requests==2.7.0
-httmock==1.2.3
-testing.postgresql==1.2.1
 psycopg2==2.6.1
 git+https://github.com/jonnybazookatone/flask-watchman@7d002bbba5babc5545f682045a2574b68908d0ce
+boto3==1.1.1


### PR DESCRIPTION
Closes issue: #10 

Added end point for ADS 2.0 libraries import.

Tests have been included.

The infrastructure assumes the following:

  - users.json in S3 on adsabs-monogut
  - all users have a library.json, where the library ID is the name
  - users.json is loaded on app load
  - libraries are requested from S3 and loaded in StringIO