### PR TITLE
Hotfix: properly urlencode plus sign

### DIFF
--- a/harbour/config.py
+++ b/harbour/config.py
@@ -1,4 +1,5 @@
-ADS_CLASSIC_URL = 'http://{mirror}/email={email}&password={password}'
+# encoding: utf-8
+ADS_CLASSIC_URL = 'http://{mirror}'
 ADS_CLASSIC_LIBRARIES_URL = 'http://{mirror}/cookie={cookie}'
 ADS_CLASSIC_MIRROR_LIST = [
     'adstrio.cfa.harvard.edu',

--- a/harbour/views.py
+++ b/harbour/views.py
@@ -458,17 +458,23 @@ class AuthenticateUserClassic(BaseView):
         # Create the correct URL
         url = current_app.config['ADS_CLASSIC_URL'].format(
             mirror=classic_mirror,
-            email=classic_email,
-            password=classic_password
         )
+        params = {
+            'man_cmd': 'elogin',
+            'man_email': classic_email,
+            'man_passwd': classic_password
+        }
 
         # Authenticate
         current_app.logger.info(
             'User "{email}" trying to authenticate at mirror "{mirror}"'
-                .format(email=classic_email, mirror=classic_mirror)
+            .format(email=classic_email, mirror=classic_mirror)
         )
         try:
-            response = requests.post(url)
+            response = requests.post(
+                url,
+                params=params
+            )
         except requests.exceptions.Timeout:
             current_app.logger.warning(
                 'ADS Classic end point timed out, returning to user'
@@ -569,8 +575,8 @@ class AuthenticateUserTwoPointOh(BaseView):
     def post(self):
         """
         HTTP POST request that receives the user's ADS 2.0 credentials, and
-        then contacts the Classic system to check that what the user provided is
-        indeed valid. If valid, the users ID is stored.
+        then contacts the Classic system to check that what the user provided
+        is indeed valid. If valid, the users ID is stored.
 
         Post body:
         ----------
@@ -609,9 +615,12 @@ class AuthenticateUserTwoPointOh(BaseView):
         # Create the correct URL
         url = current_app.config['ADS_CLASSIC_URL'].format(
             mirror=current_app.config['ADS_TWO_POINT_OH_MIRROR'],
-            email=twopointoh_email,
-            password=twopointoh_password
         )
+        params = {
+            'man_cmd': 'elogin',
+            'man_email': twopointoh_email,
+            'man_passwd': twopointoh_password
+        }
 
         # Authenticate
         current_app.logger.info(
@@ -619,7 +628,10 @@ class AuthenticateUserTwoPointOh(BaseView):
             .format(email=twopointoh_email)
         )
         try:
-            response = requests.post(url)
+            response = requests.post(
+                url,
+                params=params
+            )
         except requests.exceptions.Timeout:
             current_app.logger.warning(
                 'ADS Classic end point timed out, returning to user'


### PR DESCRIPTION
When creating the URL by hand with params, it will encode the +
(plus sign) as a space %20. This can be avoided by using the
requests params keyword that will encode it properly as a %2B.

CHANGES.md updated for the new release.